### PR TITLE
Add unit tests derived from example programs

### DIFF
--- a/app/src/test/java/org/garret/perst/DecimalExampleTest.java
+++ b/app/src/test/java/org/garret/perst/DecimalExampleTest.java
@@ -1,0 +1,46 @@
+package org.garret.perst;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DecimalExampleTest {
+    static final int INT_DIGITS = 5;
+    static final int FRAC_DIGITS = 2;
+
+    @Test
+    public void decimalOperations() {
+        Decimal d1 = new Decimal(12345, INT_DIGITS, FRAC_DIGITS);
+        Decimal d2 = new Decimal(12.34, INT_DIGITS, FRAC_DIGITS);
+        Decimal d3 = new Decimal("1.23", INT_DIGITS, FRAC_DIGITS);
+        Decimal d4 = new Decimal("00001.00");
+        Decimal d5 = new Decimal(-12345, INT_DIGITS, FRAC_DIGITS);
+        Decimal d6 = new Decimal(-12.34, INT_DIGITS, FRAC_DIGITS);
+        Decimal d7 = new Decimal("    -1.23", INT_DIGITS, FRAC_DIGITS);
+        Decimal d8 = new Decimal("-00001.00");
+
+        assertEquals(new Decimal(13579, INT_DIGITS, FRAC_DIGITS), d1.add(d2));
+        assertEquals(new Decimal(13579, INT_DIGITS, FRAC_DIGITS), d1.sub(d6));
+        assertEquals(1, d3.floor());
+        assertEquals(-2, d7.floor());
+        assertEquals(1, d4.floor());
+        assertEquals(-1, d8.floor());
+        assertEquals(2, d3.ceil());
+        assertEquals(-1, d7.ceil());
+        assertEquals(1, d4.ceil());
+        assertEquals(-1, d8.ceil());
+        assertEquals(1, d3.round());
+        assertEquals(-1, d7.round());
+        assertEquals(1, d4.round());
+        assertEquals(-1, d8.round());
+        assertEquals(d5, d1.neg());
+        assertEquals(d8, d4.neg());
+        assertTrue(d1.compareTo(d2) > 0);
+        assertTrue(d3.compareTo(d2) < 0);
+        assertTrue(d5.compareTo(d6) < 0);
+        assertTrue(d7.compareTo(d6) > 0);
+        assertEquals(0, d4.compareTo(d8.abs()));
+        assertEquals("   123.45", d1.toString(' '));
+        assertEquals("  -123.45", d5.toString(' '));
+        assertEquals("123.45", d1.toString());
+    }
+}

--- a/app/src/test/java/org/garret/perst/PatriciaTrieExampleTest.java
+++ b/app/src/test/java/org/garret/perst/PatriciaTrieExampleTest.java
@@ -1,0 +1,27 @@
+package org.garret.perst;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class PatriciaTrieExampleTest {
+    @Test
+    public void prefixSearch() {
+        Storage db = StorageFactory.getInstance().createStorage();
+        db.open(new NullFile(), Storage.INFINITE_PAGE_POOL);
+        try {
+            PatriciaTrie root = db.createPatriciaTrie();
+            db.setRoot(root);
+
+            root.add(PatriciaTrieKey.from8bitString("724885"), new PersistentString("ATT"));
+            root.add(PatriciaTrieKey.from8bitString("72488547"), new PersistentString("BCC"));
+            db.commit();
+
+            assertEquals("ATT", root.findExactMatch(PatriciaTrieKey.from8bitString("724885")).toString());
+            assertEquals("BCC", root.findExactMatch(PatriciaTrieKey.from8bitString("72488547")).toString());
+
+            assertNull(root.findExactMatch(PatriciaTrieKey.from8bitString("123456")));
+        } finally {
+            db.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- port Decimal and PatriciaTrie example programs into Gradle-run JUnit tests
- ensure tests run against in-memory storage

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a55052d90c8330bf6a6c3f1d549e67